### PR TITLE
STAT: Fixed issue with incorrect PWD passed by VS-Code to terminal

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -5,7 +5,7 @@ name: Regression
 
 on:
   push:
-    branches: [master, develop, feature/**]
+    branches: [master, develop, feature/**, bugfix/**]
     paths-ignore: ['docs/**', '*.md']
   pull_request:
     branches: [master]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Release name format: [2.2.1] - 2020-02-02
 
 None
 
+## [2.1.2] - 2020-12-12
+
+## Fixed
+
+- In REH-based Linux the VS-Code workspace had issues with relative paths used for CWD of build-tasks
+
 ## [2.1.1] - 2020-11-24
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ An open source project thrives on contribution of different people, and it may c
 - Eitan Talianker  
 [![GitHub](https://img.shields.io/badge/@etalianker-blue.svg?style=social&logo=GitHub)](https://github.com/etalianker)
 - Dr. Eitan Farchi  
-[![GitHub](https://img.shields.io/badge/@farchi@il.ibm.com-blue.svg?style=social&logo=IBM)](mailto:farchi@il.ibm.com)
+[![GitHub](https://img.shields.io/badge/farchi@il.ibm.com-blue.svg?style=social&logo=IBM)](mailto:farchi@il.ibm.com)
 - Udi Arie  
 [![GitHub](https://img.shields.io/badge/@udiarie-blue.svg?style=social&logo=GitHub)](https://github.com/udiarie)
-- Oran DeBotton
-[![GitHub](https://img.shields.io/badge/SolarEdge-@oran.debotton@SolarEdge.com-blue.svg?style=social)](mailto:oran.debotton@SolarEdge.com)
+- Oran DeBotton  
+[![GitHub](https://img.shields.io/badge/SolarEdge-oran.debotton@SolarEdge.com-blue.svg?style=social)](mailto:oran.debotton@SolarEdge.com)
+- Luna Benarroch  
+[![GitHub](https://img.shields.io/badge/luna.benarroch@ibm.com-blue.svg?style=social&logo=IBM)](mailto:luna.benarroch@ibm.com)
 
 ### 6.2. Imported Components
 

--- a/stat_attributes.py
+++ b/stat_attributes.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 # ----------------------------------------------------------------------------------------------------------------------
-VERSION = '2.1.1'
+VERSION = '2.1.2'
 
 WEB_URL = "https://github.com/westerndigitalcorporation/stat#3-usage"
 RESOURCES_DIRECTORY = 'resources'

--- a/tests/test_vscode_writer.py
+++ b/tests/test_vscode_writer.py
@@ -63,7 +63,7 @@ class TestVsCodeWriterOnNativeOs(FileBasedTestCase):
             "debug.inlineValues": True,
             "debug.showBreakpointsInOverviewRuler": True,
             "debug.toolBarLocation": "docked",
-            "terminal.integrated.cwd": "${workspaceFolder}/../../",
+            "terminal.integrated.cwd": "${workspaceFolder}/../..",
             "C_Cpp.default.includePath": includes,
             "C_Cpp.default.defines": self.makefileProject.definitions,
             # "files.exclude": {"**/node_modules": True,},
@@ -98,13 +98,13 @@ class TestVsCodeWriterOnNativeOs(FileBasedTestCase):
                         "isDefault": True
                     },
                     "options": {
-                        "cwd": "../.."
+                        "cwd": "${workspaceFolder}/../.."
                     },
                     "problemMatcher": {
                         "owner": "cpp",
                         "fileLocation": [
                             "relative",
-                            "../.."
+                            "${workspaceFolder}/../.."
                         ],
                         "pattern": {
                             "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
@@ -130,7 +130,7 @@ class TestVsCodeWriterOnNativeOs(FileBasedTestCase):
                     "command": self.makeTool,
                     "args": self.makeArguments + ["clean"],
                     "options": {
-                        "cwd": "../.."
+                        "cwd": "${workspaceFolder}/../.."
                     },
                     "problemMatcher": []
                 },

--- a/vscode_writer.py
+++ b/vscode_writer.py
@@ -50,7 +50,7 @@ class VsCodeWriter(IdeWriter):
             "debug.inlineValues": True,
             "debug.showBreakpointsInOverviewRuler": True,
             "debug.toolBarLocation": "docked",
-            "terminal.integrated.cwd": "${workspaceFolder}/../../",
+            "terminal.integrated.cwd": "${workspaceFolder}/../..",
             "C_Cpp.default.includePath": includes,
             "C_Cpp.default.defines": defines,
         }
@@ -92,7 +92,7 @@ class VsCodeWriter(IdeWriter):
             "command": command[0],
             "args": command[1:],
             "options": {
-                "cwd": "../.."
+                "cwd": "${workspaceFolder}/../.."
             },
             "problemMatcher": []
         }
@@ -102,7 +102,7 @@ class VsCodeWriter(IdeWriter):
         build["args"].remove("clean")
         build["problemMatcher"] = {
             "owner": "cpp",
-            "fileLocation": ["relative", "../.."],
+            "fileLocation": ["relative", "${workspaceFolder}/../.."],
             "pattern": {"regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
                         "file": 1, "line": 2, "column": 3, "severity": 4, "message": 5}
         }


### PR DESCRIPTION
In REH-based Linux the VS-Code workspace had issues with relative paths
used for CWD of build-tasks. The problem got fixed by proper manipulation
of CWD field of the generated VS-Code workspace.

Signed-off-by: Arseniy Aharonov <arseniy@aharonov.icu>