### PR TITLE
[CI] Fixed CI issues due to outdated configurations/tools

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-2016, windows-latest, ubuntu-16.04, ubuntu-20.04]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11]
   
     steps:
     
@@ -28,10 +28,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Python 2.7 dependencies
-      if: ${{ matrix.python-version == 2.7 }}
-      run: |
-        pip install mock==1.0.1
+#    - name: Install Python 2.7 dependencies
+#      if: ${{ matrix.python-version == 2.7 }}
+#      run: |
+#        pip install mock==1.0.1
 
     - name: Install common dependencies
       run: |

--- a/.github/workflows/vs_ide.yml
+++ b/.github/workflows/vs_ide.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: [2.7, 3.8]
+        python-version: [3.10, 3.11]
   
     steps:
     

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -39,5 +39,3 @@ Files: resources/gmake/*
 Copyright: Copyright (C) 1988-2020 Free Software Foundation, Inc.
 License: GPL-3.0-or-later
 Comment: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
-This is free software: you are free to change and redistribute it.
-There is NO WARRANTY, to the extent permitted by law.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ All notable changes to this project will be documented in this file.
 Release name format: [2.2.1] - 2020-02-02
 -->
 
+## Next Release
+
+### Fixed
+
+- Fixed CI issues with non-compliant text in `dep5` file
+
+### Removed
+
+- Removed official support of Python 2.7 as its support was dropped by GitHub containers
+
+
 ## [2.1.7] - 2021-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![GNU](https://img.shields.io/badge/GNU-Make%20|%20GCC-blue?style=flat&logo=GNU&logoColor=white) 
 ![Windows](https://img.shields.io/badge/Windows-7%20|%2010-blue?style=flat&logo=Windows&logoColor=white) 
 ![Linux](https://img.shields.io/badge/Linux-Debian%20Derivatives%20+-blue?style=flat&logo=Linux&logoColor=white) 
-![python](https://img.shields.io/badge/python-2.7%20|%203.5--3.8-blue?style=flat&logo=Python&logoColor=white)  
+![python](https://img.shields.io/badge/python-3.5--3.11-blue?style=flat&logo=Python&logoColor=white)  
 [![standard-readme compliant](https://img.shields.io/badge/readme_style-standard-brightgreen)](https://github.com/RichardLitt/standard-readme)
 [![REUSE Compliance](https://github.com/westerndigitalcorporation/stat/workflows/REUSE%20Compliance/badge.svg?branch=master)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
 [![Regression](https://github.com/westerndigitalcorporation/stat/workflows/Regression/badge.svg?branch=master)](https://github.com/westerndigitalcorporation/stat/actions?query=workflow%3ARegression+branch%3Amaster)


### PR DESCRIPTION
- `dep5` file format changed, which required removing some conflicting lines
- Python 2.7 is no longer available for regression testing on GitHub container images => it's official support is dropped no by STAT